### PR TITLE
Update devops recipes for ci-push-gcr to use the new gcloudKey integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ to GCR
 ## Run CI for this repo on Shippable
 * Fork this repo into your local repo
 * Login into the [Continuous Integration Service](wwww.shippable.com)
-* Create a GCR [integration](http://docs.shippable.com/integrations/imageRegistries/gcr/) on shippable to connect your GCR account
+* Create a Google Cloud [integration](http://docs.shippable.com/platform/integration/gcloudKey/) on shippable to connect your GCR account
 * All CI configuration is in `shippable.yml`
 * Follow these [CI Setup Instructions](http://docs.shippable.com/ci/runFirstBuild/) if you have never used Shippable CI Service
 * Update the integrationName in the integration.hub section if you used something other than `gcr-integration`

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ to GCR
 ## Run CI for this repo on Shippable
 * Fork this repo into your local repo
 * Login into the [Continuous Integration Service](wwww.shippable.com)
-* Create a Google Cloud [integration](http://docs.shippable.com/platform/integration/gcloudKey/) on shippable to connect your Google Cloud account
+* Create a Google Cloud [integration](http://docs.shippable.com/platform/integration/gcloudKey/) on shippable to connect your Google Cloud account.
 * All CI configuration is in `shippable.yml`
 * Follow these [CI Setup Instructions](http://docs.shippable.com/ci/runFirstBuild/) if you have never used Shippable CI Service
 * Update the integrationName in the integration.hub section if you used something other than `gcloud-integration`

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ to GCR
 ## Run CI for this repo on Shippable
 * Fork this repo into your local repo
 * Login into the [Continuous Integration Service](wwww.shippable.com)
-* Create a Google Cloud [integration](http://docs.shippable.com/platform/integration/gcloudKey/) on shippable to connect your GCR account
+* Create a Google Cloud [integration](http://docs.shippable.com/platform/integration/gcloudKey/) on shippable to connect your Google Cloud account
 * All CI configuration is in `shippable.yml`
 * Follow these [CI Setup Instructions](http://docs.shippable.com/ci/runFirstBuild/) if you have never used Shippable CI Service
-* Update the integrationName in the integration.hub section if you used something other than `gcr-integration`
+* Update the integrationName in the integration.hub section if you used something other than `gcloud-integration`
 * Change the IMAGE_REPO and GCP_PROJECT_ID to point to your repo and Google Cloud Platform project id
 * You should be able to run a manual build or webhook build on commit
 

--- a/shippable.yml
+++ b/shippable.yml
@@ -15,33 +15,42 @@ env:
     - CODE_COVERAGE_DIR=$SHIPPABLE_REPO_DIR/shippable/codecoverage
     - TESTS_LOC_DIR=$SHIPPABLE_REPO_DIR/tests
     - MOD_LOC=$SHIPPABLE_REPO_DIR/node_modules/.bin/
-    - IMAGE_REPO=ci-push-gcr
-    - GCP_PROJECT_ID=vidya-project
+    - IMAGE_REPO=drydockpython
+    - GCP_PROJECT_ID=lithe-camp-182705
 
 build:
-
+  pre_ci_boot:
+    image_name: asia.gcr.io/lithe-camp-182705/drydockpython
+    image_tag: latest
+    pull: true
+    #env: FOO=bar
+    #options: "-e HOME=/root"
+    #echo "hello"
   # http://docs.shippable.com/ci/shippableyml/#ci
   ci:
     # npm mirrors can sometimes be flacky, better to use shippable_retry
     # http://docs.shippable.com/ci/advancedOptions/retry/
-    - shippable_retry npm install
-    - mkdir -p $TEST_RESULTS_DIR && mkdir -p $CODE_COVERAGE_DIR
-    - pushd $TESTS_LOC_DIR
-    - $MOD_LOC/mocha --recursive "$TESTS_LOC_DIR/**/*.spec.js" -R mocha-junit-reporter --reporter-options mochaFile=$TEST_RESULTS_DIR/testresults.xml
-    - $MOD_LOC/istanbul --include-all-sources cover -root "$SHIPPABLE_REPO_DIR/routes" $SHIPPABLE_REPO_DIR/node_modules/mocha/bin/_mocha -- -R spec-xunit-file --recursive "$TESTS_LOC_DIR/**/*.spec.js"
-    - $MOD_LOC/istanbul report cobertura --dir $CODE_COVERAGE_DIR
-    - popd
+    #- shippable_retry npm install
+    #- mkdir -p $TEST_RESULTS_DIR && mkdir -p $CODE_COVERAGE_DIR
+    #- pushd $TESTS_LOC_DIR
+    #- $MOD_LOC/mocha --recursive "$TESTS_LOC_DIR/**/*.spec.js" -R mocha-junit-reporter --reporter-options mochaFile=$TEST_RESULTS_DIR/testresults.xml
+    #- $MOD_LOC/istanbul --include-all-sources cover -root "$SHIPPABLE_REPO_DIR/routes" $SHIPPABLE_REPO_DIR/node_modules/mocha/bin/_mocha -- -R spec-xunit-file --recursive "$TESTS_LOC_DIR/**/*.spec.js"
+    #- $MOD_LOC/istanbul report cobertura --dir $CODE_COVERAGE_DIR
+    - echo "new gcloudKey test"
+    #- gcloud projects list
+    - echo "custom image has cloud installed and logged in"
 
   # http://docs.shippable.com/ci/shippableyml/#post_ci
   post_ci:
-    - docker build -t gcr.io/$GCP_PROJECT_ID/$IMAGE_REPO:$BRANCH.$BUILD_NUMBER .
-    - docker push gcr.io/$GCP_PROJECT_ID/$IMAGE_REPO:$BRANCH.$BUILD_NUMBER
+    - docker build -t asia.gcr.io/$GCP_PROJECT_ID/$IMAGE_REPO:$BRANCH.$BUILD_NUMBER .
+    - docker push asia.gcr.io/$GCP_PROJECT_ID/$IMAGE_REPO:$BRANCH.$BUILD_NUMBER
 
 # Integrations are used to connect external resources to CI
 # http://docs.shippable.com/integrations/overview/
-integrations:
+#integrations:
   # adding docker hub integration so that credentials are available to CI Job
   # http://docs.shippable.com/ci/push-gcr/
-  hub:
-    - integrationName: gcr-integration
-      type: gcloudKey
+#  hub:
+#    - integrationName: gcloud
+#      type: gcloudKey
+      #agent_only: true

--- a/shippable.yml
+++ b/shippable.yml
@@ -5,7 +5,7 @@ language: node_js
 # http://docs.shippable.com/ci/advancedOptions/branches/
 branches:
   only:
-    - devops-recipes
+    - master
 
 # using pre-defined build variables
 # full list http://docs.shippable.com/ci/advancedOptions/environmentVariables/

--- a/shippable.yml
+++ b/shippable.yml
@@ -44,4 +44,4 @@ integrations:
   # http://docs.shippable.com/ci/push-gcr/
   hub:
     - integrationName: gcr-integration
-      type: gcr
+      type: gcloudKey

--- a/shippable.yml
+++ b/shippable.yml
@@ -52,5 +52,5 @@ integrations:
   # http://docs.shippable.com/ci/push-gcr/
   hub:
     - integrationName: gcloud
-      type: gcloudKey
+      type: gcr
       #agent_only: true

--- a/shippable.yml
+++ b/shippable.yml
@@ -15,35 +15,27 @@ env:
     - CODE_COVERAGE_DIR=$SHIPPABLE_REPO_DIR/shippable/codecoverage
     - TESTS_LOC_DIR=$SHIPPABLE_REPO_DIR/tests
     - MOD_LOC=$SHIPPABLE_REPO_DIR/node_modules/.bin/
-    - IMAGE_REPO=drydockpython
-    - GCP_PROJECT_ID=lithe-camp-182705
+    - IMAGE_REPO=ci-push-gcr
+    - GCP_PROJECT_ID=vidya-project
 
 build:
-  pre_ci_boot:
-    image_name: asia.gcr.io/lithe-camp-182705/drydockpython
-    image_tag: latest
-    pull: true
-    #env: FOO=bar
-    #options: "-e HOME=/root"
-    #echo "hello"
+
   # http://docs.shippable.com/ci/shippableyml/#ci
   ci:
     # npm mirrors can sometimes be flacky, better to use shippable_retry
     # http://docs.shippable.com/ci/advancedOptions/retry/
-    #- shippable_retry npm install
-    #- mkdir -p $TEST_RESULTS_DIR && mkdir -p $CODE_COVERAGE_DIR
-    #- pushd $TESTS_LOC_DIR
-    #- $MOD_LOC/mocha --recursive "$TESTS_LOC_DIR/**/*.spec.js" -R mocha-junit-reporter --reporter-options mochaFile=$TEST_RESULTS_DIR/testresults.xml
-    #- $MOD_LOC/istanbul --include-all-sources cover -root "$SHIPPABLE_REPO_DIR/routes" $SHIPPABLE_REPO_DIR/node_modules/mocha/bin/_mocha -- -R spec-xunit-file --recursive "$TESTS_LOC_DIR/**/*.spec.js"
-    #- $MOD_LOC/istanbul report cobertura --dir $CODE_COVERAGE_DIR
-    - echo "new gcloudKey test"
-    #- gcloud projects list
-    - echo "custom image has cloud installed and logged in"
+    - shippable_retry npm install
+    - mkdir -p $TEST_RESULTS_DIR && mkdir -p $CODE_COVERAGE_DIR
+    - pushd $TESTS_LOC_DIR
+    - $MOD_LOC/mocha --recursive "$TESTS_LOC_DIR/**/*.spec.js" -R mocha-junit-reporter --reporter-options mochaFile=$TEST_RESULTS_DIR/testresults.xml
+    - $MOD_LOC/istanbul --include-all-sources cover -root "$SHIPPABLE_REPO_DIR/routes" $SHIPPABLE_REPO_DIR/node_modules/mocha/bin/_mocha -- -R spec-xunit-file --recursive "$TESTS_LOC_DIR/**/*.spec.js"
+    - $MOD_LOC/istanbul report cobertura --dir $CODE_COVERAGE_DIR
+    - popd
 
   # http://docs.shippable.com/ci/shippableyml/#post_ci
   post_ci:
-    - docker build -t asia.gcr.io/$GCP_PROJECT_ID/$IMAGE_REPO:$BRANCH.$BUILD_NUMBER .
-    - docker push asia.gcr.io/$GCP_PROJECT_ID/$IMAGE_REPO:$BRANCH.$BUILD_NUMBER
+    - docker build -t gcr.io/$GCP_PROJECT_ID/$IMAGE_REPO:$BRANCH.$BUILD_NUMBER .
+    - docker push gcr.io/$GCP_PROJECT_ID/$IMAGE_REPO:$BRANCH.$BUILD_NUMBER
 
 # Integrations are used to connect external resources to CI
 # http://docs.shippable.com/integrations/overview/
@@ -51,6 +43,5 @@ integrations:
   # adding docker hub integration so that credentials are available to CI Job
   # http://docs.shippable.com/ci/push-gcr/
   hub:
-    - integrationName: gcloud
-      type: gcr
-      #agent_only: true
+    - integrationName: gcloud-integration
+      type: gcloudKey

--- a/shippable.yml
+++ b/shippable.yml
@@ -5,7 +5,7 @@ language: node_js
 # http://docs.shippable.com/ci/advancedOptions/branches/
 branches:
   only:
-    - master
+    - devops-recipes
 
 # using pre-defined build variables
 # full list http://docs.shippable.com/ci/advancedOptions/environmentVariables/

--- a/shippable.yml
+++ b/shippable.yml
@@ -43,5 +43,5 @@ integrations:
   # adding docker hub integration so that credentials are available to CI Job
   # http://docs.shippable.com/ci/push-gcr/
   hub:
-    - integrationName: gcloud-integration
+    - integrationName: gcr-integration # we need to replace here with your Google Cloud integration name
       type: gcloudKey

--- a/shippable.yml
+++ b/shippable.yml
@@ -47,10 +47,10 @@ build:
 
 # Integrations are used to connect external resources to CI
 # http://docs.shippable.com/integrations/overview/
-#integrations:
+integrations:
   # adding docker hub integration so that credentials are available to CI Job
   # http://docs.shippable.com/ci/push-gcr/
-#  hub:
-#    - integrationName: gcloud
-#      type: gcloudKey
+  hub:
+    - integrationName: gcloud
+      type: gcloudKey
       #agent_only: true


### PR DESCRIPTION
https://github.com/Shippable/pm/issues/9269
build link: https://app.shippable.com/github/mohit5it9/ci-push-gcr/runs/6/1/console